### PR TITLE
Update default number of credits

### DIFF
--- a/pages/create.js
+++ b/pages/create.js
@@ -19,7 +19,7 @@ const defaultGlobalSettings = {
   event_title: "",
   event_description: "",
   num_voters: 10,
-  credits_per_voter: 100,
+  credits_per_voter: 99,
   start_event_date: moment(),
   end_event_date: moment().add(1, "days"),
 };


### PR DESCRIPTION
If voters can only cast integer numbers of voice credits, "99" credits are better than "100" because the voter is thus forced to allocate credits to at least two options if he or she wants to use them all.