### PR TITLE
Fixing schema issues when uuid module is not enable

### DIFF
--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 CREATE TABLE "public"."Events"
 (
   id uuid DEFAULT uuid_generate_v4 (),


### PR DESCRIPTION
### What has changed?
I've added postgres function in which verifies if the module uuid-ossp is active, when its not, enables it on given database. I had problems while trying to import the given schema at `prisma/schema.sql`, due to the missing module.
### What should I pay attention when reviewing this PR?
Nothing in particular
### Is this PR dangerous?
No.

