### PR TITLE
allow arbitrary number of voters

### DIFF
--- a/pages/create.js
+++ b/pages/create.js
@@ -44,13 +44,13 @@ export default function Create() {
   const [loading, setLoading] = useState(false);
 
   /**
-   * Sets the number of voters (between 1 - 250)
+   * Sets the number of voters (min. 1)
    * @param {number} value number of voters
    */
   const setNumVoters = (value) => {
     setGlobalSettings({
       ...globalSettings, // Current settings
-      num_voters: Math.max(1, Math.min(1000, Number(Math.round(value)))), // Number between 1 - 250 and not decimal
+      num_voters: Math.max(1, Number(Math.round(value))), // Number above 1 and not decimal
     });
   };
 


### PR DESCRIPTION
Currently, the number of voters is a maximum of 1000. This pull request allows an arbitrary number of them.

The change was based on this comment in the Discord:

> Hi, I’m attempting to convince my [organisation] to switch to QV. One of the issues brought up is that the capability of the application offered on the RxC website has capacity 1000 when [my organisation] would need a theoretical operating capacity of 48,000 (obviously turnout is significantly lower however.) I’m not particularly technical but I imagine that a. This would be very feasible to design and b. there’s plenty of people on this chat who are able to create this. So I’m wondering if anybody knows of a pre-existing service, or would be theoretically willing to help participate in creating/implementing a feasible platform to do this. Obviously this is very early stages so please give any advice.