### PR TITLE
Add public shareable voting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ them mid-event.
 Existing events created before this feature shipped display as
 **Anonymous** on their settings page and cannot be switched.
 
+## Voter access
+
+Independently of `privacy_mode`, each event chooses a `link_mode` that
+determines how voters reach the ballot:
+
+- **Per-voter link** (`unique`, default) — the organizer pre-allocates
+  `num_voters` ballot rows at event creation, each with its own personal
+  URL. Each link can submit one ballot. Suitable for known voter rosters
+  where one-person-one-vote matters. This matches the behavior of every
+  event created before `link_mode` was introduced; existing events are
+  migrated to `unique` explicitly.
+- **Public link** (`public`) — a single URL anyone can visit at
+  `/vote?event=<event_uuid>`. No voter rows are pre-allocated; each
+  submission creates its own row at vote time.
+
+> Public mode is intentionally low-trust. The same person can submit
+> multiple times by reloading the page or sharing the link further.
+> Suitable for demos, workshops, and classroom polls — not for
+> consequential votes.
+
+All four (`privacy_mode` × `link_mode`) combinations are supported and
+behave independently. The two axes are locked separately once the first
+vote is cast — the API returns 409 if either is changed after voting
+begins.
+
 ## Run locally
 
 1. Setup your PostgreSQL database

--- a/lib/access.js
+++ b/lib/access.js
@@ -1,0 +1,63 @@
+// Pure, side-effect-free helpers for the event link_mode setting.
+// Mirrors the shape of lib/privacy.js so the two axes stay parallel.
+
+const LINK_MODES = Object.freeze({
+  UNIQUE: "unique",
+  PUBLIC: "public",
+});
+
+const DEFAULT_LINK_MODE = LINK_MODES.UNIQUE;
+
+function isValidLinkMode(value) {
+  return value === LINK_MODES.UNIQUE || value === LINK_MODES.PUBLIC;
+}
+
+// Normalizes an incoming link_mode value from a request body. Falls back
+// to the default when missing/empty; throws on anything else so the API
+// can reject the request rather than silently coerce. Same semantics as
+// normalizePrivacyMode in lib/privacy.js.
+function normalizeLinkMode(value) {
+  if (value === undefined || value === null || value === "") {
+    return DEFAULT_LINK_MODE;
+  }
+  if (!isValidLinkMode(value)) {
+    throw new Error(`Invalid link_mode: ${value}`);
+  }
+  return value;
+}
+
+// Constructs the data shape suitable for prisma.voters.create({data}) when
+// a public-mode submission arrives without a voter id. The new row carries
+// the event's subject definitions zipped with the submitted vote values,
+// in the same {title, description, url, votes, ...} shape that pre-allocated
+// voter rows use (see pages/api/events/create.js for the source shape).
+//
+// Pure and deterministic; safe to call any number of times. Repeat
+// submissions from the same client produce independent rows — the caller
+// just calls this again for each submission.
+//
+// `eventSubjects` is the parsed event.event_data array. `submittedVotes`
+// is the array of integer vote counts from the request body, indexed
+// positionally against `eventSubjects`. Missing entries default to 0 so
+// a short or malformed `submittedVotes` doesn't blow up the new row.
+function buildNewPublicVoterRow({ eventUuid, eventSubjects, voterName, submittedVotes }) {
+  const subjects = Array.isArray(eventSubjects) ? eventSubjects : [];
+  const votes = Array.isArray(submittedVotes) ? submittedVotes : [];
+  const vote_data = subjects.map((subject, i) => ({
+    ...subject,
+    votes: typeof votes[i] === "number" ? votes[i] : 0,
+  }));
+  return {
+    event_uuid: eventUuid,
+    voter_name: typeof voterName === "string" ? voterName : "",
+    vote_data,
+  };
+}
+
+module.exports = {
+  LINK_MODES,
+  DEFAULT_LINK_MODE,
+  isValidLinkMode,
+  normalizeLinkMode,
+  buildNewPublicVoterRow,
+};

--- a/pages/api/events/create.js
+++ b/pages/api/events/create.js
@@ -2,6 +2,7 @@
 import prisma from "db"; // Import prisma
 import moment from "moment"; // Time formatting
 import { normalizePrivacyMode } from "lib/privacy";
+import { normalizeLinkMode, LINK_MODES } from "lib/access";
 
 // --> /api/events/create
 export default async (req, res) => {
@@ -10,8 +11,10 @@ export default async (req, res) => {
   const vote_data = [];
 
   let privacy_mode;
+  let link_mode;
   try {
     privacy_mode = normalizePrivacyMode(event.privacy_mode);
+    link_mode = normalizeLinkMode(event.link_mode);
   } catch (err) {
     return res.status(400).send(err.message);
   }
@@ -25,10 +28,15 @@ export default async (req, res) => {
     });
   }
 
-  // Fill array with voter data based on num_voters in request body
-  const voters = new Array(event.num_voters).fill({
-    vote_data: vote_data, // Placeholder zeroed vote_data
-  });
+  // Voter rows are only pre-allocated for unique-link events. Public-link
+  // events skip pre-allocation entirely — each ballot submission creates
+  // its own row at vote time (pages/api/events/vote.js).
+  const shouldPreAllocate = link_mode === LINK_MODES.UNIQUE;
+  const voters = shouldPreAllocate
+    ? new Array(event.num_voters).fill({
+        vote_data: vote_data, // Placeholder zeroed vote_data
+      })
+    : [];
 
   // Create new event
   const createdEvent = await prisma.events.create({
@@ -42,7 +50,8 @@ export default async (req, res) => {
       // Stringify voteable subject data
       event_data: JSON.stringify(event.subjects),
       privacy_mode: privacy_mode,
-      // Create voters from filled array
+      link_mode: link_mode,
+      // Create voters from filled array (empty for public-link events)
       Voters: { create: voters },
     },
     select: {

--- a/pages/api/events/find.js
+++ b/pages/api/events/find.js
@@ -1,65 +1,115 @@
 import prisma from "db"; // Import prisma
+import { LINK_MODES } from "lib/access";
 
 // --> /api/events/find
+//
+// Two query shapes:
+//   ?id=<voter_uuid>     unique-link voter resuming/visiting their personal
+//                        ballot. Returns the voter's existing vote_data.
+//   ?event=<event_uuid>  public-link visitor with no prior row. Returns a
+//                        fresh zeroed vote_data built from event subjects.
+//                        Rejected for unique-mode events (no anonymous
+//                        browse path there).
 export default async (req, res) => {
-  const {
-    query: { id },
-  } = req; // Collect voter ID from request body
+  const { id, event: eventQuery } = req.query;
 
-  // If GET request passes ID param
   if (id) {
-    const response = {
-      exists: false,
-      event_id: "",
-      voter_name: "",
-      vote_data: "",
-      event_data: {},
-    }; // Setup response object
+    return findByVoterId(id, res);
+  }
+  if (eventQuery) {
+    return findByEventId(eventQuery, res);
+  }
+  return res.status(400).send("Provide either id (voter) or event (public)");
+};
 
-    // Collect voter information
-    const user = await prisma.voters.findUnique({
-      // With ID from request body
-      where: {
-        id: id,
+async function findByVoterId(id, res) {
+  const response = {
+    exists: false,
+    event_id: "",
+    voter_name: "",
+    vote_data: "",
+    event_data: {},
+  };
+
+  const user = await prisma.voters.findUnique({ where: { id } });
+
+  if (user) {
+    response.exists = true;
+    response.event_id = user.event_uuid;
+    response.voter_name = user.voter_name;
+    response.vote_data = user.vote_data;
+
+    const event_data = await prisma.events.findUnique({
+      where: { id: user.event_uuid },
+      select: {
+        event_title: true,
+        event_description: true,
+        start_event_date: true,
+        end_event_date: true,
+        credits_per_voter: true,
+        privacy_mode: true,
+        link_mode: true,
       },
     });
 
-    // If voter exists in database
-    if (user) {
-      // Toggle response object exist field
-      response.exists = true;
-      // Set response event_id field to value retrived from DB
-      response.event_id = user.event_uuid;
-      // Set respons object voter_name field to value retrieved from DB
-      response.voter_name = user.voter_name;
-      // Set response object vote_data field to value retrieved from DB
-      response.vote_data = user.vote_data;
-
-      // Collect misc event data
-      const event_data = await prisma.events.findUnique({
-        // By searching for the Event ID from table of Events
-        where: {
-          id: user.event_uuid,
-        },
-        // And selecting the appropriate fields
-        select: {
-          event_title: true,
-          event_description: true,
-          start_event_date: true,
-          end_event_date: true,
-          credits_per_voter: true,
-          privacy_mode: true,
-        },
-      });
-
-      // Set response object field to values retrieved from DB
-      response.event_data = event_data;
-    }
-
-    // Send edited/unedited response object
-    res.send(response);
-  } else {
-    // Else, without ID param, return 500
-    res.status(500).send("No ID Provided");
+    response.event_data = event_data;
   }
-};
+
+  res.send(response);
+}
+
+async function findByEventId(eventId, res) {
+  const event = await prisma.events.findUnique({
+    where: { id: eventId },
+    select: {
+      id: true,
+      event_title: true,
+      event_description: true,
+      start_event_date: true,
+      end_event_date: true,
+      credits_per_voter: true,
+      privacy_mode: true,
+      link_mode: true,
+      event_data: true,
+    },
+  });
+
+  if (!event) {
+    return res.status(404).send("Event not found");
+  }
+  if (event.link_mode !== LINK_MODES.PUBLIC) {
+    // No anonymous browse for unique-mode events. Voter needs their
+    // personal link.
+    return res
+      .status(403)
+      .send("This event requires a personal voting link. Contact the organizer.");
+  }
+
+  const subjects =
+    typeof event.event_data === "string"
+      ? JSON.parse(event.event_data)
+      : event.event_data;
+
+  // Build a fresh, zeroed vote_data shape — same shape as a pre-allocated
+  // voter row would have, so the ballot page renders identically.
+  const fresh_vote_data = (Array.isArray(subjects) ? subjects : []).map((s) => ({
+    ...s,
+    votes: 0,
+  }));
+
+  res.send({
+    exists: true,
+    event_id: event.id,
+    voter_name: "",
+    vote_data: fresh_vote_data,
+    event_data: {
+      event_title: event.event_title,
+      event_description: event.event_description,
+      start_event_date: event.start_event_date,
+      end_event_date: event.end_event_date,
+      credits_per_voter: event.credits_per_voter,
+      privacy_mode: event.privacy_mode,
+      link_mode: event.link_mode,
+    },
+  });
+}

--- a/pages/api/events/update.js
+++ b/pages/api/events/update.js
@@ -4,6 +4,7 @@ import {
   isValidPrivacyMode,
   hasAnyVoteBeenCast,
 } from "lib/privacy";
+import { isValidLinkMode } from "lib/access";
 
 // --> /api/events/update
 export default async (req, res) => {
@@ -14,23 +15,36 @@ export default async (req, res) => {
     end_event_date: formatAsPGTimestamp(new_data.end_event_date),
   };
 
-  // privacy_mode is optional on update. When present, it must be a known
-  // value AND no voter may have already cast a vote — the privacy contract
-  // can't change underneath voters who've already submitted under one mode.
-  if (new_data.privacy_mode !== undefined) {
-    if (!isValidPrivacyMode(new_data.privacy_mode)) {
-      return res.status(400).send(`Invalid privacy_mode: ${new_data.privacy_mode}`);
-    }
+  // Both privacy_mode and link_mode are optional and independently
+  // locked after the first vote — voters can't have either contract
+  // changed underneath them mid-event. We query voters at most once.
+  const wantsPrivacyChange = new_data.privacy_mode !== undefined;
+  const wantsLinkChange = new_data.link_mode !== undefined;
+
+  if (wantsPrivacyChange && !isValidPrivacyMode(new_data.privacy_mode)) {
+    return res.status(400).send(`Invalid privacy_mode: ${new_data.privacy_mode}`);
+  }
+  if (wantsLinkChange && !isValidLinkMode(new_data.link_mode)) {
+    return res.status(400).send(`Invalid link_mode: ${new_data.link_mode}`);
+  }
+
+  if (wantsPrivacyChange || wantsLinkChange) {
     const voters = await prisma.voters.findMany({
       where: { event_uuid: new_data.id },
       select: { vote_data: true },
     });
     if (hasAnyVoteBeenCast(voters)) {
+      if (wantsPrivacyChange) {
+        return res
+          .status(409)
+          .send("Privacy mode is locked: at least one voter has already submitted a vote.");
+      }
       return res
         .status(409)
-        .send("Privacy mode is locked: at least one voter has already submitted a vote.");
+        .send("Link mode is locked: at least one voter has already submitted a vote.");
     }
-    updateData.privacy_mode = new_data.privacy_mode;
+    if (wantsPrivacyChange) updateData.privacy_mode = new_data.privacy_mode;
+    if (wantsLinkChange) updateData.link_mode = new_data.link_mode;
   }
 
   await prisma.events.update({

--- a/pages/api/events/vote.js
+++ b/pages/api/events/vote.js
@@ -1,10 +1,18 @@
 import prisma from "db"; // Import prisma
 import moment from "moment"; // Time formatting
 import { validateVoteSubmission } from "lib/privacy";
+import { LINK_MODES, buildNewPublicVoterRow } from "lib/access";
 
 // --> /api/events/vote
 export default async (req, res) => {
   const vote = req.body; // Collect vote data from POST
+
+  // Public-mode submission path: no voter id, look up event by event_id and
+  // create a fresh Voters row. Branches at the top so the existing
+  // unique-mode flow below is unchanged.
+  if (!vote.id) {
+    return handlePublicSubmission(vote, res);
+  }
 
   // Look for current JSON data
   const { vote_data } = await prisma.voters.findUnique({
@@ -73,3 +81,66 @@ export default async (req, res) => {
     res.status(400).send("Invalid voter link")
   }
 };
+
+// Handles a public-mode submission (no voter id in the request body). The
+// caller has already determined there's no voter id; we resolve the event,
+// confirm it's actually in public mode, run privacy/name validation, and
+// create a fresh Voters row. Repeat submissions from the same client
+// each go through this path independently — that's by design for public
+// mode (each visit is its own row).
+async function handlePublicSubmission(vote, res) {
+  if (!vote.event_id) {
+    return res.status(400).send("Missing event_id");
+  }
+
+  const event = await prisma.events.findUnique({
+    where: { id: vote.event_id },
+    select: {
+      id: true,
+      start_event_date: true,
+      end_event_date: true,
+      privacy_mode: true,
+      link_mode: true,
+      event_data: true,
+    },
+  });
+
+  if (!event) {
+    return res.status(404).send("Event not found");
+  }
+  if (event.link_mode !== LINK_MODES.PUBLIC) {
+    // Defense-in-depth: a unique-mode event must never accept a
+    // no-voter-id submission, even if a client constructed one manually.
+    return res.status(400).send("This event requires a personal voting link.");
+  }
+
+  const validation = validateVoteSubmission({
+    privacyMode: event.privacy_mode,
+    name: vote.name,
+  });
+  if (validation.error) {
+    return res.status(400).send(validation.error);
+  }
+
+  if (
+    !(moment() > moment(event.start_event_date) &&
+      moment() < moment(event.end_event_date))
+  ) {
+    return res.status(400).send("Voting is closed for this event");
+  }
+
+  const subjects =
+    typeof event.event_data === "string"
+      ? JSON.parse(event.event_data)
+      : event.event_data;
+
+  const rowData = buildNewPublicVoterRow({
+    eventUuid: event.id,
+    eventSubjects: subjects,
+    voterName: validation.name,
+    submittedVotes: vote.votes,
+  });
+
+  await prisma.voters.create({ data: rowData });
+  res.status(200).send("Successful submission");
+}

--- a/pages/create.js
+++ b/pages/create.js
@@ -23,6 +23,7 @@ const defaultGlobalSettings = {
   start_event_date: moment(),
   end_event_date: moment().add(1, "days"),
   privacy_mode: "anonymous",
+  link_mode: "unique",
 };
 
 // Initial empty subject
@@ -206,17 +207,19 @@ export default function Create() {
             />
           </div>
 
-          {/* Number of voters selection */}
-          <div className="create__settings_section">
-            <label htmlFor="num_voters">Number of voters</label>
-            <p>How many voting links would you like to generate?</p>
-            <input
-              type="number"
-              id="num_voters"
-              value={globalSettings.num_voters}
-              onChange={(e) => setNumVoters(e.target.value)}
-            />
-          </div>
+          {/* Number of voters selection — only meaningful for unique-link events */}
+          {globalSettings.link_mode === "unique" ? (
+            <div className="create__settings_section">
+              <label htmlFor="num_voters">Number of voters</label>
+              <p>How many voting links would you like to generate?</p>
+              <input
+                type="number"
+                id="num_voters"
+                value={globalSettings.num_voters}
+                onChange={(e) => setNumVoters(e.target.value)}
+              />
+            </div>
+          ) : null}
 
           {/* Number of credits per voter selection */}
           <div className="create__settings_section">
@@ -292,6 +295,52 @@ export default function Create() {
                 </span>
               </label>
             </div>
+          </div>
+
+          {/* Voter access (link mode) selection */}
+          <div className="create__settings_section">
+            <label>Voter access</label>
+            <p>How will voters reach the ballot?</p>
+            <div className="privacy__option">
+              <label className="privacy__option_label">
+                <input
+                  type="radio"
+                  name="link_mode"
+                  value="unique"
+                  checked={globalSettings.link_mode === "unique"}
+                  onChange={(e) => setEventData("link_mode", e.target.value)}
+                />
+                <span>
+                  <strong>Per-voter link</strong> — generate a personal voting
+                  link for each voter. Each link can submit one ballot. Suitable
+                  for known voter rosters.
+                </span>
+              </label>
+            </div>
+            <div className="privacy__option">
+              <label className="privacy__option_label">
+                <input
+                  type="radio"
+                  name="link_mode"
+                  value="public"
+                  checked={globalSettings.link_mode === "public"}
+                  onChange={(e) => setEventData("link_mode", e.target.value)}
+                />
+                <span>
+                  <strong>Public link</strong> — a single URL anyone can use to
+                  vote. The same person can submit multiple times by reloading
+                  the page. Suitable for demos, workshops, and classroom polls
+                  — not for consequential votes.
+                </span>
+              </label>
+            </div>
+            {globalSettings.link_mode === "public" &&
+            globalSettings.privacy_mode === "identified" ? (
+              <p className="privacy__warning">
+                Names are self-reported and not verified. Use for low-stakes
+                contexts only.
+              </p>
+            ) : null}
           </div>
         </div>
 
@@ -640,6 +689,16 @@ export default function Create() {
         }
         .privacy__option_label > input {
           margin-top: 4px;
+        }
+        .privacy__warning {
+          margin-top: 14px !important;
+          padding: 8px 10px;
+          background-color: #fff5d0;
+          border: 1px solid #fada5e;
+          border-radius: 5px;
+          color: #000;
+          font-size: 14px;
+          line-height: 140%;
         }
         .create__submission {
           margin: 0px auto;

--- a/pages/event.js
+++ b/pages/event.js
@@ -16,6 +16,71 @@ import { buildVotersSheet, shouldIncludeVotersSheet } from "lib/export";
 // Setup fetcher for SWR
 const fetcher = (url) => fetch(url).then((r) => r.json());
 
+// Displays the public voting URL for an event in public link mode, with a
+// copy-to-clipboard button. URL is built client-side from
+// window.location.origin so we don't hard-code the deployment domain.
+function PublicVotingUrl({ eventId }) {
+  const [url, setUrl] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // window is only defined client-side; safe inside useEffect.
+    setUrl(`${window.location.origin}/vote?event=${eventId}`);
+  }, [eventId]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (_) {
+      // Clipboard may be unavailable (e.g. insecure context). Fall back
+      // by selecting the input so the user can copy manually.
+      const el = document.getElementById("public_voting_url");
+      if (el) {
+        el.focus();
+        el.select();
+      }
+    }
+  };
+
+  return (
+    <div className="public__url">
+      <input id="public_voting_url" value={url} readOnly />
+      <button type="button" onClick={copy}>
+        {copied ? "Copied!" : "Copy"}
+      </button>
+      <style jsx>{`
+        .public__url {
+          display: grid;
+          grid-template-columns: 1fr auto;
+          gap: 8px;
+          margin-top: 12px;
+        }
+        .public__url > input {
+          font-size: 16px;
+          border-radius: 5px;
+          border: 1px solid #f1f2e5;
+          padding: 8px 10px;
+          background-color: #fff;
+        }
+        .public__url > button {
+          padding: 8px 14px;
+          border-radius: 5px;
+          background-color: #000;
+          color: #edff38;
+          border: none;
+          cursor: pointer;
+          font-size: 14px;
+        }
+        .public__url > button:hover {
+          opacity: 0.85;
+        }
+      `}</style>
+    </div>
+  );
+}
+
 function Event({ query }) {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -292,6 +357,21 @@ function Event({ query }) {
                 ? "Identified — voter names will appear in the downloaded report (per-voter export ships in a follow-up release)."
                 : "Anonymous — voter names are not included in the downloaded report."}
             </p>
+          </div>
+        ) : null}
+
+        {/* Link mode (read-only) + public URL display when applicable */}
+        {!loading && data ? (
+          <div className="event__section">
+            <label>Voter access</label>
+            <p>
+              {data.event.link_mode === "public"
+                ? "Public link — anyone with the URL below can vote. The same person can submit multiple times."
+                : "Per-voter link — each voter has a personal link that can submit one ballot."}
+            </p>
+            {data.event.link_mode === "public" ? (
+              <PublicVotingUrl eventId={query.id} />
+            ) : null}
           </div>
         ) : null}
 

--- a/pages/success.js
+++ b/pages/success.js
@@ -3,13 +3,19 @@ import Layout from "components/layout"; // Layout wrapper
 import Navigation from "components/navigation"; // Navigation component
 
 function Success({ query }) {
+  // Public-link submitters have no voter id to round-trip — each visit is
+  // independent — so "Change your votes" only makes sense for unique-link
+  // voters whose row we can resume.
+  const hasVoter = !!query.user;
+  const backToVote = hasVoter ? `/vote?user=${query.user}` : "/";
+  const backToVoteLabel = hasVoter ? "Voting" : "Home";
   return (
     <Layout>
       {/* Navigation header */}
       <Navigation
         history={{
-          title: "Voting",
-          link: `/vote?user=${query.user}`,
+          title: backToVoteLabel,
+          link: backToVote,
         }}
         title="Vote Success"
       />
@@ -19,10 +25,12 @@ function Success({ query }) {
         <h1>Your vote is in!</h1>
         <p>You have successfully placed your votes.</p>
 
-        {/* Go back to voting */}
-        <Link href={`/vote?user=${query.user}`}>
-          <a>Change your votes</a>
-        </Link>
+        {/* Go back to voting (only for unique-link voters) */}
+        {hasVoter ? (
+          <Link href={`/vote?user=${query.user}`}>
+            <a>Change your votes</a>
+          </Link>
+        ) : null}
 
         {/* Redirect to event dashboard */}
         <Link href={`/event?id=${query.event}`}>

--- a/pages/vote.js
+++ b/pages/vote.js
@@ -17,6 +17,11 @@ function Vote({ query }) {
   const [votes, setVotes] = useState(null); // Option votes array
   const [credits, setCredits] = useState(0); // Total available credits
   const [submitLoading, setSubmitLoading] = useState(false); // Component (button) submission loading state
+  const [accessError, setAccessError] = useState(""); // Inline error for public-visit failures
+
+  // Public-mode visits use ?event=<id> with no voter id. Per-voter visits
+  // use ?user=<voter_id>. Computed once per render.
+  const isPublicVisit = !query.user && !!query.event;
 
   /**
    * Calculates culmulative number of votes and available credits on load
@@ -60,9 +65,42 @@ function Vote({ query }) {
   };
 
   /**
-   * componentDidMount
+   * componentDidMount — branches on URL pattern.
+   *
+   *   ?user=<voter_id>   per-voter unique-link flow (existing behavior)
+   *   ?event=<event_id>  public-link flow (new). The find endpoint rejects
+   *                      this query with 403 if the event is unique-mode,
+   *                      which we surface inline rather than redirecting.
+   *   neither            redirect to /place (matches existing fallback)
    */
   useEffect(() => {
+    if (isPublicVisit) {
+      axios
+        .get(`/api/events/find?event=${query.event}`)
+        .then((response) => {
+          setData(response.data);
+          setName("");
+          calculateVotes(response.data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          // 403 → unique-mode mismatch; surface server's message inline.
+          // 404 → event not found; same treatment.
+          const msg =
+            err && err.response && typeof err.response.data === "string"
+              ? err.response.data
+              : "This event requires a personal voting link. Contact the organizer.";
+          setAccessError(msg);
+          setLoading(false);
+        });
+      return;
+    }
+
+    if (!query.user) {
+      router.push("/place?error=true");
+      return;
+    }
+
     // Collect voter information on load
     axios
       .get(`/api/events/find?id=${query.user}`)
@@ -131,7 +169,10 @@ function Vote({ query }) {
   const canSubmit = () => !isIdentified() || name.trim() !== "";
 
   /**
-   * Vote submission POST
+   * Vote submission POST. Two body shapes depending on the visit type:
+   *   per-voter: { id: <voter_id>, votes, name }
+   *   public:    { event_id: <event_id>, votes, name }
+   * The server distinguishes by presence/absence of `id`.
    */
   const submitVotes = async () => {
     // Identified-mode events require a non-empty name. Mirror the server-side
@@ -143,24 +184,29 @@ function Vote({ query }) {
     // Toggle button loading state to true
     setSubmitLoading(true);
 
-    try {
-      // POST data and collect status
-      const { status } = await axios.post("/api/events/vote", {
-        id: query.user, // Voter ID
-        votes: votes, // Vote data
-        name: name, // Voter name
-      });
+    const body = isPublicVisit
+      ? { event_id: data.event_id, votes: votes, name: name }
+      : { id: query.user, votes: votes, name: name };
 
-      // If POST is a success
+    // Success/failure URLs vary too — public visits have no voter id to
+    // round-trip, so the thank-you page renders without a "Change your
+    // votes" link.
+    const successUrl = isPublicVisit
+      ? `success?event=${data.event_id}`
+      : `success?event=${data.event_id}&user=${query.user}`;
+    const failureUrl = isPublicVisit
+      ? `failure?event=${data.event_id}`
+      : `failure?event=${data.event_id}&user=${query.user}`;
+
+    try {
+      const { status } = await axios.post("/api/events/vote", body);
       if (status === 200) {
-        // Redirect to success page
-        router.push(`success?event=${data.event_id}&user=${query.user}`);
+        router.push(successUrl);
       } else {
-        // Else, redirec to failure page
-        router.push(`failure?event=${data.event_id}&user=${query.user}`);
+        router.push(failureUrl);
       }
     } catch (_) {
-      router.push(`failure?event=${data.event_id}&user=${query.user}`);
+      router.push(failureUrl);
     }
 
     // Toggle button loading state to false
@@ -210,8 +256,20 @@ function Vote({ query }) {
       />
 
       <div className="vote">
+        {/* Inline error for public visits where the event isn't public,
+            doesn't exist, or otherwise can't be browsed. */}
+        {accessError ? (
+          <div className="vote__loading">
+            <h1>Can't open this ballot</h1>
+            <p>{accessError}</p>
+            <p>
+              <a href="/">Back to home</a>
+            </p>
+          </div>
+        ) : null}
+
         {/* Loading state check */}
-        {!loading ? (
+        {!loading && !accessError ? (
           <>
           <aside id="table-of-contents_container">
             <div className="toc-header">
@@ -427,13 +485,14 @@ function Vote({ query }) {
             </div>
           </div>
           </>
-        ) : (
-          // If loading, show global loading state
+        ) : !accessError ? (
+          // If loading, show global loading state. Suppressed when an
+          // access error is already on screen.
           <div className="vote__loading">
             <h1>Loading...</h1>
             <p>Please give us a moment to retrieve your voting profile.</p>
           </div>
-        )}
+        ) : null}
       </div>
 
       {/* Component scoped CSS */}

--- a/prisma/migrations/2026_05_27_add_link_mode.sql
+++ b/prisma/migrations/2026_05_27_add_link_mode.sql
@@ -1,0 +1,15 @@
+-- Adds link_mode to Events. Default is 'unique' (today's per-voter-link
+-- behavior). The 'public' value enables a single shareable URL for the
+-- event with no per-voter pre-allocation.
+--
+-- Existing events were created under the unique-link contract — voters
+-- received personal links generated from pre-allocated Voters rows — so
+-- we set their value explicitly rather than relying on the column default.
+-- Same auditable pattern as 2026_05_27_add_privacy_mode.sql.
+
+ALTER TABLE "public"."Events"
+  ADD COLUMN link_mode VARCHAR NOT NULL DEFAULT 'unique';
+
+UPDATE "public"."Events"
+  SET link_mode = 'unique'
+  WHERE link_mode IS NULL OR link_mode <> 'unique';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Events {
   created_at        DateTime @default(now())
   event_data        Json?
   privacy_mode      String   @default("anonymous")
+  link_mode         String   @default("unique")
   Voters            Voters[]
 }
 

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE "public"."Events"
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   event_data JSON,
   privacy_mode VARCHAR NOT NULL DEFAULT 'anonymous',
+  link_mode VARCHAR NOT NULL DEFAULT 'unique',
   PRIMARY KEY (id)
 );
 

--- a/scripts/test-access.js
+++ b/scripts/test-access.js
@@ -1,0 +1,277 @@
+// Runnable unit tests for lib/access.js. No test framework — `node` only.
+// Run from the project root:
+//
+//   node scripts/test-access.js
+//
+// Exits non-zero on first failure with a diff-style message.
+//
+// Covers the link_mode axis introduced in this PR:
+//   - validator + normalizer mirror the privacy_mode shape
+//   - default is 'unique' so existing events behave identically post-migration
+//   - buildNewPublicVoterRow constructs an independent row per call (so
+//     repeat submissions from the same client each get their own row,
+//     each with the event's credit allocation implicit in the empty
+//     starting state)
+//   - hasAnyVoteBeenCast (reused from lib/privacy.js) covers the lock
+//     in both directions — same predicate, same answer
+//   - all four (privacy_mode × link_mode) combinations validate cleanly
+//     and produce sensible row data
+
+const assert = require("assert");
+const path = require("path");
+
+const access = require(path.join(__dirname, "..", "lib", "access.js"));
+const privacy = require(path.join(__dirname, "..", "lib", "privacy.js"));
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+// ---------------------------------------------------------------------------
+// normalizeLinkMode / DEFAULT_LINK_MODE
+// ---------------------------------------------------------------------------
+
+test("default link mode is unique", () => {
+  assert.strictEqual(access.DEFAULT_LINK_MODE, "unique");
+});
+
+test("missing link_mode normalizes to unique", () => {
+  assert.strictEqual(access.normalizeLinkMode(undefined), "unique");
+  assert.strictEqual(access.normalizeLinkMode(null), "unique");
+  assert.strictEqual(access.normalizeLinkMode(""), "unique");
+});
+
+test("known link modes round-trip", () => {
+  assert.strictEqual(access.normalizeLinkMode("unique"), "unique");
+  assert.strictEqual(access.normalizeLinkMode("public"), "public");
+});
+
+test("unknown link mode throws (parallels privacy_mode)", () => {
+  assert.throws(() => access.normalizeLinkMode("invitelink"), /Invalid link_mode/);
+  assert.throws(() => access.normalizeLinkMode("Unique"), /Invalid link_mode/);
+  assert.throws(() => access.normalizeLinkMode(0), /Invalid link_mode/);
+});
+
+test("isValidLinkMode rejects unknown values", () => {
+  assert.strictEqual(access.isValidLinkMode("unique"), true);
+  assert.strictEqual(access.isValidLinkMode("public"), true);
+  assert.strictEqual(access.isValidLinkMode("invitelink"), false);
+  assert.strictEqual(access.isValidLinkMode(undefined), false);
+});
+
+// ---------------------------------------------------------------------------
+// Migration semantics — explicit-UPDATE pattern
+// ---------------------------------------------------------------------------
+//
+// We can't apply the SQL here, but the migration file's intent is checkable:
+// it must explicitly set existing rows to 'unique' rather than relying on
+// the column default. Locating the UPDATE string in the migration file is
+// a low-cost proxy that catches accidental deletion of the explicit UPDATE.
+
+test("migration explicitly UPDATEs existing rows to 'unique'", () => {
+  const fs = require("fs");
+  const file = fs.readFileSync(
+    path.join(__dirname, "..", "prisma", "migrations", "2026_05_27_add_link_mode.sql"),
+    "utf8"
+  );
+  assert.ok(file.includes("ADD COLUMN link_mode"), "migration must add the column");
+  assert.ok(/UPDATE\s+"public"\."Events"\s+SET\s+link_mode\s*=\s*'unique'/i.test(file),
+    "migration must explicitly UPDATE existing rows to 'unique'");
+});
+
+// ---------------------------------------------------------------------------
+// buildNewPublicVoterRow — fresh row per call, correct shape
+// ---------------------------------------------------------------------------
+
+function publicEventFixture() {
+  return {
+    eventUuid: "evt-1",
+    eventSubjects: [
+      { title: "Option A", description: "first", url: "" },
+      { title: "Option B", description: "second", url: "" },
+      { title: "Option C", description: "third", url: "" },
+    ],
+  };
+}
+
+test("buildNewPublicVoterRow produces a row with event_uuid + voter_name + vote_data", () => {
+  const fx = publicEventFixture();
+  const row = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: "Alice",
+    submittedVotes: [2, 0, -1],
+  });
+  assert.strictEqual(row.event_uuid, "evt-1");
+  assert.strictEqual(row.voter_name, "Alice");
+  assert.strictEqual(row.vote_data.length, 3);
+});
+
+test("buildNewPublicVoterRow preserves subject metadata + adds vote values", () => {
+  const fx = publicEventFixture();
+  const row = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: "Alice",
+    submittedVotes: [2, 0, -1],
+  });
+  assert.deepStrictEqual(row.vote_data, [
+    { title: "Option A", description: "first", url: "", votes: 2 },
+    { title: "Option B", description: "second", url: "", votes: 0 },
+    { title: "Option C", description: "third", url: "", votes: -1 },
+  ]);
+});
+
+test("buildNewPublicVoterRow returns independent objects per call (no shared state)", () => {
+  const fx = publicEventFixture();
+  const row1 = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: "Alice",
+    submittedVotes: [1, 0, 0],
+  });
+  const row2 = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: "Alice",
+    submittedVotes: [0, 2, 0],
+  });
+  // Mutating row1 must NOT affect row2.
+  row1.vote_data[0].votes = 99;
+  assert.strictEqual(row2.vote_data[0].votes, 0);
+  // The two rows are genuinely distinct allocations.
+  assert.notDeepStrictEqual(row1.vote_data, row2.vote_data);
+});
+
+test("buildNewPublicVoterRow tolerates missing/short submittedVotes (zeros default)", () => {
+  const fx = publicEventFixture();
+  const row = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: "Alice",
+    submittedVotes: [3], // only one value provided
+  });
+  assert.strictEqual(row.vote_data[0].votes, 3);
+  assert.strictEqual(row.vote_data[1].votes, 0);
+  assert.strictEqual(row.vote_data[2].votes, 0);
+});
+
+test("buildNewPublicVoterRow coerces non-string voterName to empty string", () => {
+  const fx = publicEventFixture();
+  const row = access.buildNewPublicVoterRow({
+    eventUuid: fx.eventUuid,
+    eventSubjects: fx.eventSubjects,
+    voterName: undefined,
+    submittedVotes: [0, 0, 0],
+  });
+  assert.strictEqual(row.voter_name, "");
+});
+
+// ---------------------------------------------------------------------------
+// Lock-after-first-vote (reuses hasAnyVoteBeenCast from lib/privacy.js)
+// ---------------------------------------------------------------------------
+
+test("link_mode lock check: no votes → both directions allowed", () => {
+  const fresh = [{ vote_data: [{ votes: 0 }, { votes: 0 }] }];
+  // hasAnyVoteBeenCast returning false means update.js permits the change.
+  assert.strictEqual(privacy.hasAnyVoteBeenCast(fresh), false);
+});
+
+test("link_mode lock check: any nonzero vote → locked (covers both directions)", () => {
+  const voted = [
+    { vote_data: [{ votes: 0 }] },
+    { vote_data: [{ votes: 1 }] },
+  ];
+  // Same predicate gates unique→public and public→unique. The 409 message
+  // differs in update.js but the lock condition is identical.
+  assert.strictEqual(privacy.hasAnyVoteBeenCast(voted), true);
+});
+
+// ---------------------------------------------------------------------------
+// Combination matrix: privacy_mode × link_mode at the helper level
+// ---------------------------------------------------------------------------
+//
+// We can't exercise the API stack from a plain-node script, but we can
+// validate that the helper layer accepts every (privacy, link) combination
+// and produces sensible artifacts. Each combination should:
+//   - normalize both fields cleanly (no throws)
+//   - validate a vote submission consistent with the privacy mode
+//   - build a public-voter row when applicable
+
+const matrix = [
+  { privacy: "anonymous", link: "unique" },
+  { privacy: "anonymous", link: "public" },
+  { privacy: "identified", link: "unique" },
+  { privacy: "identified", link: "public" },
+];
+
+for (const combo of matrix) {
+  test(`combo: ${combo.privacy} + ${combo.link} normalizes cleanly`, () => {
+    assert.strictEqual(privacy.normalizePrivacyMode(combo.privacy), combo.privacy);
+    assert.strictEqual(access.normalizeLinkMode(combo.link), combo.link);
+  });
+
+  test(`combo: ${combo.privacy} + ${combo.link} accepts a valid vote submission`, () => {
+    const name = combo.privacy === "identified" ? "Alice" : "";
+    const v = privacy.validateVoteSubmission({
+      privacyMode: combo.privacy,
+      name,
+    });
+    assert.strictEqual(v.error, null, `combo ${JSON.stringify(combo)} should accept; got: ${v.error}`);
+  });
+
+  test(`combo: ${combo.privacy} + ${combo.link} rejects a name-missing vote when identified`, () => {
+    const v = privacy.validateVoteSubmission({
+      privacyMode: combo.privacy,
+      name: "",
+    });
+    if (combo.privacy === "identified") {
+      assert.ok(v.error, "identified must require a name regardless of link mode");
+    } else {
+      assert.strictEqual(v.error, null);
+    }
+  });
+
+  if (combo.link === "public") {
+    test(`combo: ${combo.privacy} + public builds a row carrying the normalized name`, () => {
+      const fx = publicEventFixture();
+      const name = combo.privacy === "identified" ? "  Alice   B  " : "";
+      const v = privacy.validateVoteSubmission({ privacyMode: combo.privacy, name });
+      assert.strictEqual(v.error, null);
+      const row = access.buildNewPublicVoterRow({
+        eventUuid: fx.eventUuid,
+        eventSubjects: fx.eventSubjects,
+        voterName: v.name,
+        submittedVotes: [1, 1, 0],
+      });
+      // Identified combo normalizes the name; anonymous combo keeps "".
+      if (combo.privacy === "identified") {
+        assert.strictEqual(row.voter_name, "Alice B");
+      } else {
+        assert.strictEqual(row.voter_name, "");
+      }
+      assert.strictEqual(row.event_uuid, fx.eventUuid);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL ${name}`);
+    console.error("       " + (err.message || err));
+    if (err.stack) console.error(err.stack.split("\n").slice(1, 4).join("\n"));
+  }
+}
+console.log("");
+console.log(`${tests.length - failed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Adds a second orthogonal axis to event configuration: how voters reach the ballot. `link_mode` (`unique` | `public`) is fully independent of `privacy_mode` from #30 — all four combinations work end-to-end. `unique` (default) preserves today's per-voter-link behavior exactly; `public` exposes a single shareable URL at `/vote?event=<event_uuid>` with no pre-allocated voter rows. Each public submission creates its own row, by design. Suitable for demos, workshops, and classroom polls — the README is explicit that public mode is low-trust and the same person can submit multiple times. Existing events are migrated to `unique` explicitly so nothing changes for them.

## Logical units

### 1. Schema + helpers

- New column `link_mode VARCHAR NOT NULL DEFAULT 'unique'` on `Events`. Migration in `prisma/migrations/2026_05_27_add_link_mode.sql` ALTERs the table AND explicitly UPDATEs existing rows to `'unique'` — same auditable pattern as #30's `privacy_mode` migration.
- [`lib/access.js`](lib/access.js) mirrors the shape of `lib/privacy.js`: `LINK_MODES`, `DEFAULT_LINK_MODE`, `isValidLinkMode`, `normalizeLinkMode`, plus `buildNewPublicVoterRow` (a pure row-builder so the public-submit path is testable without prisma).

### 2. API wiring

- [`pages/api/events/create.js`](pages/api/events/create.js) accepts `link_mode` and skips voter pre-allocation when `public`.
- [`pages/api/events/find.js`](pages/api/events/find.js) refactored into two branches: `?id=<voter>` (unchanged unique-mode flow) and `?event=<event>` (new public flow that constructs a fresh zeroed `vote_data` from event subjects). Rejects `?event=` for unique-mode events with 403.
- [`pages/api/events/vote.js`](pages/api/events/vote.js) branches at the top for no-voter-id submissions. `handlePublicSubmission` resolves the event by `event_id`, confirms `link_mode === 'public'`, runs existing privacy/name validation, and creates a new `Voters` row. Defense-in-depth 400 if a no-voter-id submission targets a unique-mode event.
- [`pages/api/events/update.js`](pages/api/events/update.js) accepts an optional `link_mode` change with a parallel lock and parallel 409 message. Reuses `hasAnyVoteBeenCast` from `lib/privacy.js`. Both axes share a single voters query.

### 3. UI

- [`pages/create.js`](pages/create.js) — radio picker for Voter access (Per-voter default / Public). The number-of-voters field is hidden when public. A yellow warning under the Public option appears when public + identified are selected together: "Names are self-reported and not verified. Use for low-stakes contexts only."
- [`pages/event.js`](pages/event.js) — read-only Voter access section adjacent to the existing Voter privacy section. When public, renders the full URL via `window.location.origin` with a copy-to-clipboard button (`PublicVotingUrl` component, with a select-the-input fallback for insecure contexts).
- [`pages/vote.js`](pages/vote.js) — branches on `query.event` vs `query.user`. Public visit builds a fresh ballot (no resumed state, no voter id persisted client-side), posts `{event_id, votes, name}`, redirects to `/success?event=<id>` (no `user`). Inline access-error block for 403/404 from the find endpoint rather than redirecting to `/place`.
- [`pages/success.js`](pages/success.js) — "Change your votes" link conditional on `query.user`, so public submitters don't see a broken link.

## Behavior changes worth noticing

- **`pages/api/events/find.js` response now includes `link_mode` in `event_data`** for both query shapes. Existing clients ignoring unknown fields are unaffected; the new field lets the ballot page render the correct flow.
- **`pages/api/events/find.js` response for `?event=<id>` differs from `?id=<voter>`** in one detail: when looking up by event, `vote_data` is freshly constructed from event subjects (all `votes: 0`) rather than read from a `Voters` row. The shape is identical, so the ballot page renders the same way.
- **No-voter-id POST to `/api/events/vote` for a unique-mode event returns 400**, not 403. The find GET uses 403 ("you know the resource exists but can't browse it this way"); the POST is closer to a malformed-request scenario, so 400 fits better. Same user-visible message in the body.
- **`pages/api/events/update.js` now queries voters at most once** per request even when both `privacy_mode` and `link_mode` are being changed. Previously the privacy-only check ran unconditionally on a privacy change; the new structure folds both into one scan.

## Manual verification checklist

Items #1 and #5 are the spec's explicit ones.

1. **Existing event still works in unique-link mode.** Open a pre-existing event's voter link `/vote?user=<voter_uuid>`. Submit. Redirect to `/success?event=<id>&user=<voter_uuid>` with both "Change your votes" and "See event dashboard" present. Re-open the voter link; previous vote state is resumed.
2. **Default mode at creation is unique.** Create with the picker left at the default. `SELECT link_mode FROM \"Events\" WHERE id = '<id>'` → `unique`. Settings page shows "Per-voter link" with no public URL field.
3. **Public mode at creation skips voter pre-allocation.** Create selecting Public. Number-of-voters input is hidden. After creation: `SELECT count(*) FROM \"Voters\" WHERE event_uuid = '<id>'` → 0. Settings page shows the public URL with a working copy button.
4. **Combined public + identified shows the warning.** On the create page with Public selected, switch privacy to Identified — yellow callout appears under the Public option. Switching either field away makes it disappear.
5. **Public mode accepts multiple submissions from the same browser.** Open public URL in incognito → vote → submit. Open public URL in a normal tab → vote (different allocation) → submit. `SELECT count(*) FROM \"Voters\" WHERE event_uuid = '<id>'` → 2. For identified events, each row has its submitted name; for anonymous events, both empty.
6. **Lock-after-first-vote works on both axes independently.** Create public + identified. Cast a nonzero vote. Then:
   - `curl -X POST /api/events/update -d '{\"id\":\"<id>\",\"link_mode\":\"unique\", ...}'` → 409 "Link mode is locked: ..."
   - `curl -X POST /api/events/update -d '{\"id\":\"<id>\",\"privacy_mode\":\"anonymous\", ...}'` → 409 "Privacy mode is locked: ..."
   - Same update with only date changes → 200 (date edits still allowed)
7. **All four privacy × link combinations work end-to-end.** Create one event per combination. Submit a vote on each. Verify the `Voters` row has the right `voter_name` (empty for anonymous, present for identified) and `vote_data`. XLSX export still behaves correctly per mode:
   - anonymous + unique → totals-only sheet (byte-identical to pre-PR — #30 invariant still holds)
   - anonymous + public → totals-only sheet
   - identified + unique → totals + Voters sheet
   - identified + public → totals + Voters sheet
8. **Unique-mode event rejects `?event=<id>`-only access cleanly.** Open `/vote?event=<unique_event_uuid>`. Inline error block shows "This event requires a personal voting link. Contact the organizer." with a Back to home link. No redirect to `/place`.
9. **Unique-mode event rejects no-voter-id POST cleanly.** `curl -X POST /api/events/vote -d '{\"event_id\":\"<unique_event_id>\",\"votes\":[1,0],\"name\":\"\"}'` → 400 "This event requires a personal voting link."
10. **Public-URL copy button.** On a public event's settings page, click Copy. Button text briefly changes to "Copied!". Paste — value matches the displayed input.
11. **Identified-mode public submissions still require a name.** Open public URL for an identified event. Try to submit without a name → submit button disabled. Type a name → enables → submit succeeds → name lands in the `Voters` row (normalized via #30's `validateVoteSubmission`).
12. **Migration applies cleanly.** Apply `prisma/migrations/2026_05_27_add_link_mode.sql` to a snapshot. Every existing `Events` row returns `unique`.
13. **`node scripts/test-access.js` exits 0** with 27 passing assertions.
14. **`node scripts/test-privacy.js` still exits 0** with 31 passing assertions (regression check that this PR didn't disturb #30).

## Spec-ambiguity decisions

- **Thank-you flow for public submitters:** redirect to `/success?event=<id>` (no `user`) and adapt `success.js` to hide "Change your votes" when `query.user` is absent. Alternatives were a second thank-you page, or a direct redirect to `/event?id=<id>`. Chose this because it reuses the existing visual treatment and keeps `/success` a single component.
- **No-voter-id POST to unique-mode event = 400 (not 403).** Find GET uses 403 because "the event exists, you just can't browse it this way." Vote POST is closer to malformed-request, so 400 fits. Same user-visible message.
- **Inline access error in `vote.js`** for failed public lookups, instead of redirecting to `/place?error=true`. `/place` prompts for a voting code, which is the wrong remediation for a public-mode mismatch.
- **`PublicVotingUrl` builds its URL inside `useEffect`** because `window.location.origin` is undefined during Next.js SSR. The input renders empty until the effect runs (one React render later, visually imperceptible).
- **Clipboard fallback:** when `navigator.clipboard` isn't available (insecure contexts, older browsers), focus and select the input so the user can `Cmd-C` manually. No alert, no error — silent graceful degradation.
- **Migration test reads the SQL file** to assert the explicit UPDATE is present. Can't apply migrations from a node script, but losing the explicit UPDATE would break the auditable-intent property the spec required.
- **Server doesn't enforce the credits-per-voter budget** for public submissions — same trust model as unique mode today. The client UI's `calculateShow` enforces the budget. Adding server-side budget enforcement is a separate concern that would affect both modes.
- **`update.js` queries voters once** even when both axes are being changed. Folded the two lock checks into one scan.

## Constraints honored

- No QV math changes.
- No new dependencies.
- No rate limiting, IP throttling, captchas, or anti-spam — explicitly out of scope per the brief.
- No URL rotation / revocation affordance — explicitly out of scope.
- Existing events behave identically to today, including pre-allocated voter rows.
- `lib/privacy.js`, `lib/export.js`, and `downloadXLSX` not touched. PR #30's byte-identical guarantee for anonymous exports still holds.

## Test plan

- [x] `node scripts/test-access.js` → 27 passing assertions
- [x] `node scripts/test-privacy.js` → 31 passing assertions (regression check)
- [ ] Manual verification checklist above

🤖 Generated with [Claude Code](https://claude.com/claude-code)