### PR TITLE
Fix public-link vote submission (Error B): use Events relation, not scalar event_uuid

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -32,6 +32,13 @@ function normalizeLinkMode(value) {
 // in the same {title, description, url, votes, ...} shape that pre-allocated
 // voter rows use (see pages/api/events/create.js for the source shape).
 //
+// The event association is emitted as the `Events` relation
+// (`Events: { connect: { id } }`), NOT as a scalar `event_uuid`. The
+// generated Prisma client's VotersCreateInput requires the relation for a
+// top-level voters.create — it exposes no writable scalar FK (this client
+// generation produces no UncheckedCreateInput), so a scalar `event_uuid`
+// is rejected with "Unknown arg `event_uuid`".
+//
 // Pure and deterministic; safe to call any number of times. Repeat
 // submissions from the same client produce independent rows — the caller
 // just calls this again for each submission.
@@ -48,9 +55,9 @@ function buildNewPublicVoterRow({ eventUuid, eventSubjects, voterName, submitted
     votes: typeof votes[i] === "number" ? votes[i] : 0,
   }));
   return {
-    event_uuid: eventUuid,
     voter_name: typeof voterName === "string" ? voterName : "",
     vote_data,
+    Events: { connect: { id: eventUuid } },
   };
 }
 

--- a/scripts/test-access.js
+++ b/scripts/test-access.js
@@ -95,7 +95,7 @@ function publicEventFixture() {
   };
 }
 
-test("buildNewPublicVoterRow produces a row with event_uuid + voter_name + vote_data", () => {
+test("buildNewPublicVoterRow produces a row with Events relation + voter_name + vote_data", () => {
   const fx = publicEventFixture();
   const row = access.buildNewPublicVoterRow({
     eventUuid: fx.eventUuid,
@@ -103,7 +103,10 @@ test("buildNewPublicVoterRow produces a row with event_uuid + voter_name + vote_
     voterName: "Alice",
     submittedVotes: [2, 0, -1],
   });
-  assert.strictEqual(row.event_uuid, "evt-1");
+  // Event association is emitted as the `Events` relation connect, not a
+  // scalar event_uuid (which the Prisma client rejects on create).
+  assert.strictEqual(row.event_uuid, undefined);
+  assert.deepStrictEqual(row.Events, { connect: { id: "evt-1" } });
   assert.strictEqual(row.voter_name, "Alice");
   assert.strictEqual(row.vote_data.length, 3);
 });
@@ -251,7 +254,7 @@ for (const combo of matrix) {
       } else {
         assert.strictEqual(row.voter_name, "");
       }
-      assert.strictEqual(row.event_uuid, fx.eventUuid);
+      assert.deepStrictEqual(row.Events, { connect: { id: fx.eventUuid } });
     });
   }
 }


### PR DESCRIPTION
## Root cause

Public-link vote submission fails at `pages/api/events/vote.js:144` (`prisma.voters.create({ data: rowData })`) with:

```
PrismaClientValidationError: Unknown arg `event_uuid` in data.event_uuid for type VotersCreateInput.
Argument Events for data.Events is missing.
```

`buildNewPublicVoterRow` (`lib/access.js`) built the row with a **scalar `event_uuid`**. In the generated Prisma client (2.13.0) shipped in this app, a top-level `voters.create` accepts only:

```ts
VotersCreateInput = { id?, voter_name?, vote_data?, Events: EventsCreateOneWithoutVotersInput }
```

The scalar FK `event_uuid` is **not** a writable create arg — this client generation emits **no `UncheckedCreateInput`** (the variant that would allow scalar FK writes; grep count = 0 in the generated `index.d.ts`). So the only valid way to associate the new voter row to its event on a standalone create is the `Events` **relation**. This matches the working per-voter path, which creates voters as a nested write under `events.create({ data: { Voters: { create: [...] } } })` and lets Prisma set the FK from the parent — it never writes a scalar `event_uuid`.

## The fix (one line of behavior)

`buildNewPublicVoterRow` now returns the relation connect shape:

```diff
- return { event_uuid: eventUuid, voter_name, vote_data };
+ return { voter_name, vote_data, Events: { connect: { id: eventUuid } } };
```

`voter_name`/`vote_data` handling is unchanged. `pages/api/events/vote.js` passes `rowData` straight through, so **no API handler change is needed**. No schema change, no migration, no Prisma client regen.

## Scope

- `lib/access.js` — corrected return shape + updated the comment describing it.
- `scripts/test-access.js` — updated the two assertions that checked the old scalar shape to assert `Events: { connect: { id } }` instead (same coverage, corrected expectation).

## Scope note — this is Error B only

This PR fixes **only** the public-link `voters.create` failure (Error B). It does **not** address, and these remain separate follow-ups:
- **Error A** — `generateStatistics` `TypeError: Cannot read property 'map' of null` in `pages/api/events/details.js` (null `vote_data`/`event_data`).
- **Data-conditional null-`vote_data` risk** in the per-voter path (`vote.js` `vote_data.length`/null-id destructure → 500 on legacy/edge rows).

## Tests

Both existing suites pass against this branch:
- `node scripts/test-access.js` → **27 passed, 0 failed**
- `node scripts/test-privacy.js` → **31 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)