### PR TITLE
Add deploy.sh and OPS.md for production QV

### DIFF
--- a/OPS.md
+++ b/OPS.md
@@ -1,0 +1,160 @@
+# QV Production Operations
+
+Operations guide for the production **Quadratic Voting (QV)** app. Keep this
+in sync with `deploy.sh`.
+
+## Architecture
+
+Everything runs on a single DigitalOcean droplet, **rxc-voice-apps**
+(`64.225.61.72`), as **five** Docker containers — one per app, each
+publishing its own host port. Access is `ssh root@64.225.61.72` (root SSH
+key). DigitalOcean load balancers sit in front and route public traffic to
+these ports.
+
+| App                | Host port | Repo dir (droplet)                                        |
+| ------------------ | --------- | --------------------------------------------------------- |
+| **quadratic-voting (QV)** | **2000** | `/home/alex/rxc-voice-apps/production/quadratic-voting` |
+| mudamos_qv         | 2001      | (separate app)                                            |
+| eng_demo           | 2002      | (separate app)                                            |
+| demo_br            | 2003      | (separate app)                                            |
+| rxc-voice_voice    | 4000      | (rxc-voice frontend)                                      |
+| rxc-voice_api      | 8000      | (rxc-voice backend)                                       |
+
+> **Only ever touch the container on port 2000.** The other four apps are
+> independent and must be left running. `deploy.sh` keys entirely off port
+> 2000 and refuses to act if the match isn't exactly one container.
+
+**Containers / images.** The QV image is `rxc_qv:latest`. Containers run with
+`--restart unless-stopped` and get auto-generated names (e.g.
+`lucid_ramanujan`, `dreamy_bardeen`) — we do not pass `--name`. **The app
+code is baked into the image (no bind mounts), so a code change requires a
+full `docker build`; a plain `docker restart` reruns the OLD code.**
+
+**Database.** Managed PostgreSQL on DigitalOcean (host
+`...-do-user-6555646-0.b.db.ondigitalocean.com`, port `25060`, the
+voice/api cluster). The QV app reads its connection string from
+`prisma/.env` (`DATABASE_URL`), which is passed into the container via
+`--env-file ./prisma/.env`.
+
+> **Credentials are not stored in this doc.** They live in `prisma/.env` on
+> the droplet (gitignored) and in the DigitalOcean control panel. Do not
+> commit them.
+
+## Deploy — normal (code-only)
+
+The common case: a merged PR with no schema changes (no new
+`prisma/migrations/`), no new dependencies.
+
+```bash
+ssh root@64.225.61.72
+cd /home/alex/rxc-voice-apps/production/quadratic-voting
+./deploy.sh
+```
+
+`deploy.sh` performs, in order:
+
+1. **Pre-flight** — confirms repo dir + on `main` + `prisma/.env` present;
+   `git fetch origin`; prints incoming commits; **migration guard** (see
+   below); tags the currently-running image as a rollback point
+   `rxc_qv:pre-deploy-<YYYY-MM-DD-HHMMSS>`.
+2. **Pull** — `git pull --ff-only origin main`.
+3. **Build** — `docker build -t rxc_qv .` (does not affect the live
+   container; aborts the deploy on failure).
+4. **Swap** — finds the single container on port 2000, stops + removes it,
+   then `docker run -d --restart unless-stopped --env-file ./prisma/.env -p 2000:2000 rxc_qv`.
+   This is the ~30s downtime window.
+5. **Health check + auto-rollback** — polls `http://localhost:2000/` for
+   ~30s. On success it prints the new image ID and the rollback command. On
+   failure it auto-rolls back to the pre-deploy tag (see Rollback).
+
+After it finishes, sanity-check manually if you like:
+
+```bash
+docker ps                                   # new container Up on :2000, other four untouched
+docker logs <new_id> --tail 50              # clean start, no DB errors
+curl -sI http://localhost:2000/ | head -5   # 200/302
+curl -sI http://localhost:2000/create | head -5
+```
+
+## Deploy — with migrations
+
+`deploy.sh` **never applies migrations.** If the pull contains any
+new/changed file under `prisma/migrations/`, the migration guard aborts the
+deploy before doing anything. Apply migrations by hand first:
+
+```bash
+ssh root@64.225.61.72
+cd /home/alex/rxc-voice-apps/production/quadratic-voting
+git fetch origin
+git diff --name-only HEAD origin/main | grep '^prisma/migrations/'   # see what's pending
+
+# Read DATABASE_URL from prisma/.env and apply the migration(s):
+export $(grep -E '^DATABASE_URL=' prisma/.env | xargs)
+psql "$DATABASE_URL" -f prisma/migrations/<file>.sql
+
+# Verify the schema actually changed (example):
+psql "$DATABASE_URL" -c '\d+ "Voters"'
+
+# Only once the DB is migrated:
+./deploy.sh
+```
+
+Notes:
+- Apply migrations in commit order if there is more than one.
+- The Prisma client is generated **at image build time** from
+  `prisma/schema.prisma`; if a migration changes the schema, make sure the
+  merged code carries the matching `schema.prisma` so the rebuilt image's
+  client matches the live DB.
+
+## Rollback
+
+Every run tags the previously-live image as
+`rxc_qv:pre-deploy-<timestamp>` **before** pulling/rebuilding, so the prior
+version is always recoverable even after `:latest` is overwritten.
+
+- **Automatic:** if the post-swap health check fails, `deploy.sh` stops/removes
+  the new container and restarts the pre-deploy-tagged image automatically,
+  then exits non-zero.
+- **Manual:** `deploy.sh` prints the exact command on every run. It looks
+  like:
+
+  ```bash
+  docker stop <new_id> && docker rm <new_id>
+  cd /home/alex/rxc-voice-apps/production/quadratic-voting && \
+    docker run -d --restart unless-stopped --env-file ./prisma/.env \
+    -p 2000:2000 rxc_qv:pre-deploy-<timestamp>
+  ```
+
+List available rollback points with `docker images | grep rxc_qv`.
+
+## Recovery notes
+
+- **Rebuild is mandatory for code changes.** Code is baked into the image
+  (no bind mounts). A `docker restart` will rerun the old code — always
+  rebuild.
+- **Restart policy** is `--restart unless-stopped`, so containers survive a
+  droplet reboot. Preserve this flag on every `docker run`.
+- **Docker won't start after a reboot?** Check `/etc/docker/daemon.json` is
+  valid JSON (`python3 -m json.tool /etc/docker/daemon.json`), then
+  `systemctl restart docker`. A malformed daemon config silently keeps the
+  daemon down.
+- **Health after a swap:** `docker logs <id> --tail 50`. Some endpoints log
+  request-driven errors that are unrelated to startup (see Known
+  follow-ups) — distinguish a crash loop from a clean
+  `ready - started server on http://localhost:2000`.
+
+## Known follow-ups
+
+- **Error A — `generateStatistics` null `.map`.** `pages/api/events/details.js`
+  throws `TypeError: Cannot read property 'map' of null` when a voter row has
+  null `vote_data`. Needs a null-guard. Request-driven, not a startup
+  failure. (Error B — public-link `voters.create` using a scalar
+  `event_uuid` — was fixed in PR #34.)
+- **Data-conditional null-`vote_data` risk** in the per-voter path
+  (`pages/api/events/vote.js`): `vote_data.length`/null-id destructure can
+  500 on legacy/edge rows. Same root cause family as Error A.
+- **Rotate secrets.** Rotate the managed-Postgres password and `APP_SECRET`;
+  update `prisma/.env` and the DO panel together.
+- **Clean up TEST events.** Diagnostic events titled `TEST - delete me`
+  (e.g. `d3a61307-...`) remain in the DB from troubleshooting; remove when
+  convenient.

--- a/OPS.md
+++ b/OPS.md
@@ -6,7 +6,7 @@ in sync with `deploy.sh`.
 ## Architecture
 
 Everything runs on a single DigitalOcean droplet, **rxc-voice-apps**
-(`64.225.61.72`), as **five** Docker containers — one per app, each
+(`64.225.61.72`), as **six** Docker containers (five apps — rxc-voice runs as two) — each
 publishing its own host port. Access is `ssh root@64.225.61.72` (root SSH
 key). DigitalOcean load balancers sit in front and route public traffic to
 these ports.
@@ -20,7 +20,7 @@ these ports.
 | rxc-voice_voice    | 4000      | (rxc-voice frontend)                                      |
 | rxc-voice_api      | 8000      | (rxc-voice backend)                                       |
 
-> **Only ever touch the container on port 2000.** The other four apps are
+> **Only ever touch the container on port 2000.** The other five apps are
 > independent and must be left running. `deploy.sh` keys entirely off port
 > 2000 and refuses to act if the match isn't exactly one container.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — production deploy for the Quadratic Voting (QV) app.
+#
+# Run ON the droplet, FROM the repo dir:
+#   ssh root@64.225.61.72
+#   cd /home/alex/rxc-voice-apps/production/quadratic-voting && ./deploy.sh
+#
+# What it does (code-only deploys): pre-flight checks -> pull -> rebuild the
+# Docker image -> swap the :2000 container -> health-check with auto-rollback.
+# The code is baked into the image (no bind mounts), so a rebuild is
+# MANDATORY — a plain restart would rerun the old code.
+#
+# This script touches ONLY the QV container on port 2000. The other four
+# apps on this droplet (eng_demo:2002, demo_br:2003, mudamos_qv:2001,
+# rxc-voice_voice:4000, rxc-voice_api:8000) are never referenced.
+#
+# It deliberately does NOT run database migrations. If a pull contains new
+# migrations it ABORTS and tells you to apply them by hand first (see OPS.md).
+
+set -euo pipefail
+
+# --- Configuration ----------------------------------------------------------
+readonly EXPECTED_DIR="/home/alex/rxc-voice-apps/production/quadratic-voting"
+readonly IMAGE="rxc_qv"            # built/tagged as rxc_qv:latest
+readonly PORT="2000"               # QV is the only app on :2000
+readonly ENV_FILE="./prisma/.env"
+readonly HEALTH_URL="http://localhost:${PORT}/"
+readonly HEALTH_RETRIES=15         # ~30s total (15 * 2s)
+readonly HEALTH_SLEEP=2
+
+# Predictable, sortable rollback tag — echoed so a human can roll back too.
+readonly TS="$(date +%Y-%m-%d-%H%M%S)"
+readonly ROLLBACK_TAG="${IMAGE}:pre-deploy-${TS}"
+
+phase() { echo; echo "==> $*"; }
+fail()  { echo; echo "!!! $*" >&2; exit 1; }
+
+# --- 1. Pre-flight ----------------------------------------------------------
+phase "PRE-FLIGHT"
+
+# Must be in the repo dir, in a git work tree, on main.
+if [ ! -f Dockerfile ] || [ ! -d prisma ]; then
+  fail "Not in the QV repo dir (no Dockerfile/prisma/ here). Expected: ${EXPECTED_DIR}"
+fi
+if [ "$(pwd -P)" != "${EXPECTED_DIR}" ]; then
+  echo "    WARNING: cwd $(pwd -P) != expected ${EXPECTED_DIR} (continuing)"
+fi
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || fail "Not a git work tree."
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "${BRANCH}" = "main" ] || fail "On branch '${BRANCH}', expected 'main'. Aborting."
+
+# Env file must exist (it lives on the droplet, gitignored).
+[ -f "${ENV_FILE}" ] || fail "Missing ${ENV_FILE} — required for --env-file. Aborting."
+
+phase "Fetching origin and showing incoming commits"
+git fetch origin
+echo "Incoming (HEAD..origin/main):"
+git log HEAD..origin/main --oneline || true
+
+# MIGRATION GUARD — never auto-apply schema changes.
+phase "Migration guard: scanning for pending migrations"
+CHANGED="$(git diff --name-only HEAD origin/main || true)"
+if echo "${CHANGED}" | grep -qE '^prisma/migrations/'; then
+  echo "Changed files under prisma/migrations/:"
+  echo "${CHANGED}" | grep -E '^prisma/migrations/' | sed 's/^/    /'
+  fail "Pending migrations detected — apply them manually with psql before \
+deploying, then re-run. See OPS.md."
+fi
+echo "    No migration changes. OK to proceed."
+
+# Tag the CURRENT running image (rxc_qv:latest == what's live right now) as a
+# rollback point BEFORE we pull/rebuild and overwrite :latest.
+phase "Tagging current image as rollback point: ${ROLLBACK_TAG}"
+docker image inspect "${IMAGE}:latest" >/dev/null 2>&1 \
+  || fail "No ${IMAGE}:latest image found to tag as rollback. Aborting."
+docker tag "${IMAGE}:latest" "${ROLLBACK_TAG}"
+echo "    Rollback tag created: ${ROLLBACK_TAG}"
+
+# --- 2. Pull ----------------------------------------------------------------
+phase "PULL: git pull --ff-only origin main"
+git pull --ff-only origin main
+echo "    New HEAD: $(git log -1 --oneline)"
+
+# --- 3. Build ---------------------------------------------------------------
+phase "BUILD: docker build -t ${IMAGE} ."
+docker build -t "${IMAGE}" . || fail "docker build failed. Nothing swapped; the live container is untouched."
+NEW_IMAGE_ID="$(docker image inspect "${IMAGE}:latest" --format '{{.Id}}')"
+echo "    Built ${IMAGE}:latest = ${NEW_IMAGE_ID}"
+
+# --- 4. Swap ----------------------------------------------------------------
+phase "SWAP: locating the single running container on port ${PORT}"
+# Port 2000 uniquely identifies QV on this droplet. Refuse to guess if the
+# match isn't exactly one container.
+mapfile -t QV_CONTAINERS < <(docker ps --filter "publish=${PORT}" --format '{{.ID}}')
+if [ "${#QV_CONTAINERS[@]}" -eq 0 ]; then
+  fail "No running container publishes port ${PORT}. Aborting (nothing to swap)."
+elif [ "${#QV_CONTAINERS[@]}" -gt 1 ]; then
+  printf '    %s\n' "${QV_CONTAINERS[@]}"
+  fail "Found ${#QV_CONTAINERS[@]} containers on port ${PORT} — expected exactly 1. Refusing to guess."
+fi
+OLD_ID="${QV_CONTAINERS[0]}"
+echo "    Will stop/remove: ${OLD_ID} ($(docker ps --filter "id=${OLD_ID}" --format '{{.Names}} ({{.Image}})'))"
+
+echo "    Stopping + removing old container ${OLD_ID} (~30s downtime starts now)"
+docker stop "${OLD_ID}" >/dev/null
+docker rm   "${OLD_ID}" >/dev/null
+
+echo "    Starting new container from ${IMAGE}:latest"
+NEW_ID="$(docker run -d --restart unless-stopped --env-file "${ENV_FILE}" -p "${PORT}:${PORT}" "${IMAGE}")"
+echo "    New container: ${NEW_ID}"
+
+# --- 5. Health check with auto-rollback -------------------------------------
+phase "HEALTH CHECK: polling ${HEALTH_URL} (up to ~$((HEALTH_RETRIES * HEALTH_SLEEP))s)"
+healthy=0
+for i in $(seq 1 "${HEALTH_RETRIES}"); do
+  if curl -sf "${HEALTH_URL}" >/dev/null 2>&1; then
+    healthy=1
+    echo "    Healthy after ${i} attempt(s)."
+    break
+  fi
+  echo "    attempt ${i}/${HEALTH_RETRIES}: not ready yet, sleeping ${HEALTH_SLEEP}s..."
+  sleep "${HEALTH_SLEEP}"
+done
+
+if [ "${healthy}" -ne 1 ]; then
+  echo
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "!!! HEALTH CHECK FAILED — AUTO-ROLLBACK to ${ROLLBACK_TAG}"
+  echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+  echo "--- last 50 log lines from the failed container (${NEW_ID}) ---"
+  docker logs "${NEW_ID}" --tail 50 2>&1 || true
+  echo "--- rolling back ---"
+  docker stop "${NEW_ID}" >/dev/null 2>&1 || true
+  docker rm   "${NEW_ID}" >/dev/null 2>&1 || true
+  docker run -d --restart unless-stopped --env-file "${ENV_FILE}" -p "${PORT}:${PORT}" "${ROLLBACK_TAG}" >/dev/null \
+    || fail "ROLLBACK FAILED to start ${ROLLBACK_TAG}. MANUAL INTERVENTION REQUIRED."
+  echo "    Rolled back to ${ROLLBACK_TAG}."
+  fail "Deploy failed and was rolled back. The new image is still tagged ${IMAGE}:latest; investigate before retrying."
+fi
+
+# --- 6. Success -------------------------------------------------------------
+phase "SUCCESS"
+echo "    QV is healthy on port ${PORT}."
+echo "    New container : ${NEW_ID}"
+echo "    New image     : ${IMAGE}:latest = ${NEW_IMAGE_ID}"
+echo "    Rollback tag  : ${ROLLBACK_TAG}"
+echo
+echo "    To roll back manually:"
+echo "      docker stop ${NEW_ID} && docker rm ${NEW_ID}"
+echo "      cd ${EXPECTED_DIR} && \\"
+echo "        docker run -d --restart unless-stopped --env-file ${ENV_FILE} -p ${PORT}:${PORT} ${ROLLBACK_TAG}"
+echo
+echo "Done."


### PR DESCRIPTION
Codifies the production deploy procedure used across the last several QV deploys as a runnable script (`deploy.sh`) plus an operations doc (`OPS.md`). **Neither file was run against production** — this PR only adds them.

## `deploy.sh` (run on the droplet, from the repo dir)

`set -euo pipefail`, echoes each phase. Steps:

1. **Pre-flight** — confirm we're in the repo dir, on `main`, with `prisma/.env` present; `git fetch origin`; print incoming `HEAD..origin/main` commits.
2. **Migration guard** — if `git diff --name-only HEAD origin/main` shows any new/changed file under `prisma/migrations/`, **ABORT** with a message telling the operator to apply them manually with psql first (see OPS.md). The script never runs migrations.
3. **Rollback tag** — tag the currently-running image as `rxc_qv:pre-deploy-<YYYY-MM-DD-HHMMSS>` *before* pulling/rebuilding, so the prior version is always recoverable after `:latest` is overwritten.
4. **Pull** — `git pull --ff-only origin main`.
5. **Build** — `docker build -t rxc_qv .` (aborts the deploy on failure; live container untouched).
6. **Swap** — find the single running container on **port 2000**; **abort if zero or more than one match** (never guess). Stop + remove it, then `docker run -d --restart unless-stopped --env-file ./prisma/.env -p 2000:2000 rxc_qv`.
7. **Health check + auto-rollback** — poll `http://localhost:2000/` for ~30s. On failure: stop/remove the new container, restart the `pre-deploy-<ts>` image, print the failed container's logs, and exit non-zero. On success: print the new image ID, the rollback tag, and the exact manual rollback command.

**Only the `:2000` container is ever referenced** — the other four apps (eng_demo:2002, demo_br:2003, mudamos_qv:2001, rxc-voice_voice:4000, rxc-voice_api:8000) are untouched. Committed with the executable bit (`100755`).

## `OPS.md`

- **Architecture** — one DO droplet (`64.225.61.72`) hosting five containers, the port map, DO load balancers, managed Postgres (host/port/dbname only; **credentials live in `prisma/.env` and the DO panel, not in the doc**).
- **Deploy (code-only)** — `ssh root@<host>` then `cd <repo> && ./deploy.sh`.
- **Deploy (with migrations)** — apply via `psql "$DATABASE_URL" -f prisma/migrations/<file>.sql` (reading `DATABASE_URL` from `prisma/.env`), verify columns, then run `deploy.sh`.
- **Rollback** — how the pre-deploy tag works + the manual command.
- **Recovery notes** — code is baked into the image (no bind mounts → rebuild mandatory); `unless-stopped` restart policy; if Docker won't start after a reboot, validate `/etc/docker/daemon.json` is valid JSON.
- **Known follow-ups** — Error A (`generateStatistics` null `.map` guard), rotate DB password + `APP_SECRET`, clean up `TEST - delete me` events.

## Verification (local, not against the droplet)

- `bash -n deploy.sh` → clean (not executed).
- `node scripts/test-access.js` → **27 passed, 0 failed**.
- `node scripts/test-privacy.js` → **31 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)