### PR TITLE
Guard null vote_data in stats + per-voter vote path (Error A)

### DIFF
--- a/pages/api/events/details.js
+++ b/pages/api/events/details.js
@@ -100,8 +100,13 @@ function generateStatistics(subjects, num_voters, credits_per_voter, voters) {
     // participation denominator (zero-fill) — identical to a normal zeroed
     // non-voter. Skip its tallying so the .map (below), .length, and
     // element access never dereference null. Mirrors the Array.isArray
-    // guard in lib/privacy.js (hasVoterVoted).
-    if (!Array.isArray(voter_data)) continue;
+    // guard in lib/privacy.js (hasVoterVoted). Warn so the same anomaly that
+    // vote.js rejects with a 409 is also detectable from the read-only stats
+    // path.
+    if (!Array.isArray(voter_data)) {
+      console.warn(`generateStatistics: skipping voter ${voter.id} with null vote_data (event ${voter.event_uuid})`);
+      continue;
+    }
 
     // Sum voter preferences to check if user has placed at least 1 vote
     const sumVotes = voter_data

--- a/pages/api/events/details.js
+++ b/pages/api/events/details.js
@@ -95,6 +95,14 @@ function generateStatistics(subjects, num_voters, credits_per_voter, voters) {
     // Collect voter preferences
     const voter_data = voter.vote_data;
 
+    // vote_data is Json? (nullable). A null/legacy row carries no votes, so
+    // it contributes nothing but remains counted in totalVoters / the
+    // participation denominator (zero-fill) — identical to a normal zeroed
+    // non-voter. Skip its tallying so the .map (below), .length, and
+    // element access never dereference null. Mirrors the Array.isArray
+    // guard in lib/privacy.js (hasVoterVoted).
+    if (!Array.isArray(voter_data)) continue;
+
     // Sum voter preferences to check if user has placed at least 1 vote
     const sumVotes = voter_data
       .map((subject) => Math.pow(subject.votes, 2))

--- a/pages/api/events/vote.js
+++ b/pages/api/events/vote.js
@@ -56,10 +56,16 @@ export default async (req, res) => {
 
     if ((moment() > moment(event_data.start_event_date)) &&
       (moment() < moment(event_data.end_event_date))) {
-      // Loop through vote_data in DB
-      for (let i = 0; i < vote_data.length; i++) {
-        // Update with new votes from request body
-        vote_data[i].votes = vote.votes[i];
+      // Loop through vote_data in DB. vote_data is Json? (nullable); a
+      // null/legacy row has no subject scaffolding to merge votes into, so
+      // guard the loop to treat null as an empty prior state (no votes
+      // recorded) instead of 500ing on `.length`. Mirrors the Array.isArray
+      // guard in lib/privacy.js and the zero-fill guard in details.js.
+      if (Array.isArray(vote_data)) {
+        for (let i = 0; i < vote_data.length; i++) {
+          // Update with new votes from request body
+          vote_data[i].votes = vote.votes[i];
+        }
       }
       // Update voter object — persist the normalized name, not raw input.
       await prisma.voters.update({

--- a/pages/api/events/vote.js
+++ b/pages/api/events/vote.js
@@ -56,16 +56,22 @@ export default async (req, res) => {
 
     if ((moment() > moment(event_data.start_event_date)) &&
       (moment() < moment(event_data.end_event_date))) {
-      // Loop through vote_data in DB. vote_data is Json? (nullable); a
-      // null/legacy row has no subject scaffolding to merge votes into, so
-      // guard the loop to treat null as an empty prior state (no votes
-      // recorded) instead of 500ing on `.length`. Mirrors the Array.isArray
-      // guard in lib/privacy.js and the zero-fill guard in details.js.
-      if (Array.isArray(vote_data)) {
-        for (let i = 0; i < vote_data.length; i++) {
-          // Update with new votes from request body
-          vote_data[i].votes = vote.votes[i];
-        }
+      // vote_data is Json? (nullable). A pre-allocated unique-link voter
+      // always has a zeroed array here, so a null is an invariant violation
+      // (legacy/manual/corrupt row), not a normal state. Surface it: log the
+      // anomaly and return 409 rather than 500ing on `.length` OR silently
+      // dropping the ballot and reporting a false 200. Mirrors the
+      // Array.isArray guard in lib/privacy.js and details.js.
+      if (!Array.isArray(vote_data)) {
+        console.error(`vote.js: null vote_data for voter ${vote.id} (event ${user.event_uuid}) — data anomaly`);
+        return res
+          .status(409)
+          .send("This voting link is in an invalid state. Please contact the organizer.");
+      }
+      // Loop through vote_data in DB
+      for (let i = 0; i < vote_data.length; i++) {
+        // Update with new votes from request body
+        vote_data[i].votes = vote.votes[i];
       }
       // Update voter object — persist the normalized name, not raw input.
       await prisma.voters.update({


### PR DESCRIPTION
## Root cause

`Voters.vote_data` is `Json?` — **nullable** — so a row can legally hold `null`. Two code paths assumed it is always an array and threw on null:

- **`pages/api/events/details.js` → `generateStatistics`** — `voter.vote_data.map(...)` threw `TypeError: Cannot read property 'map' of null` (**Error A**) whenever any voter row had `vote_data = null`. Request-driven crash of the event details/statistics endpoint, not a startup failure.
- **`pages/api/events/vote.js` → per-voter path** — `for (let i = 0; i < vote_data.length; i++)` would 500 on the **same** null-`vote_data` condition.

Under normal operation a null **cannot** occur on the per-voter path: every voter-creation path writes a non-null array (`events/create.js` pre-allocates a zeroed array for unique-link voters; `buildNewPublicVoterRow` builds an array for public voters), and no migration inserts voter rows or leaves `vote_data` null. So a null here is an **invariant violation** (legacy / manual edit / partial write / old restore), not a normal state — the guard is a defensive safety net.

## Fix — guard, and surface the anomaly (not swallow it)

Both sites guard with `Array.isArray` (mirroring `lib/privacy.js` `hasVoterVoted`), but they treat the anomaly differently per path:

- **`details.js`** (read-only stats): **`console.warn` + `continue`** — the null row is skipped (zero-fill: it contributes no votes but stays counted in `totalVoters` / the participation denominator, identical to a normal zeroed non-voter). The `continue` covers the `.map`, `.length`, and element-access sites that follow. The warn makes the anomaly detectable from the stats path.
- **`vote.js`** (write path): **`console.error` + HTTP 409**, with no fall-through to `voters.update`. A null row has no subject scaffolding to merge votes into, so rather than 500ing **or** silently dropping the ballot and returning a false `200 "Successful update"`, the voter gets `409 "This voting link is in an invalid state. Please contact the organizer."` and the anomaly is logged (voter id + event id). Since null never happens normally, this path is effectively a dead-code safety net.

Behavior for normal (array) rows is **unchanged**.

## Scope

Fixes **Error A** (stats crash) **and** the same-root-cause 500 risk in the per-voter vote path, in one PR (same defect, two files). Minimal guards, no refactor.

### Deferred follow-ups (intentionally NOT in this PR)
- `vote.js:18` null-**user** destructure — a missing/invalid voter id makes `findUnique` return null and the destructure throws. Different root cause (missing voter, not null `vote_data`).
- `details.js:42` `JSON.parse(event.event_data)` null risk (different nullable field).
- `details.js:129` `voterParticiptation` divide-by-zero when nobody voted (`numberVoters === 0` → `Infinity`/`NaN`; not a throw).
- Extracting `generateStatistics`/`calculateLinear`/`calculateQV` into a pure `lib/` module + adding stats unit tests (the stats code is currently not exported/testable).

## Tests

No new tests added — the stats code isn't extracted/testable yet (deferred above). Existing suites still pass:
- `node scripts/test-access.js` → **27 passed, 0 failed**
- `node scripts/test-privacy.js` → **31 passed, 0 failed**

Not deployed, not run against the droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)