### PR TITLE
Fix 500 on invalid voter link (null findUnique destructure)

### DIFF
--- a/pages/api/events/vote.js
+++ b/pages/api/events/vote.js
@@ -15,12 +15,22 @@ export default async (req, res) => {
   }
 
   // Look for current JSON data
-  const { vote_data } = await prisma.voters.findUnique({
+  const voterRow = await prisma.voters.findUnique({
     // Using individual, secret vote ID passed from request body
     where: { id: vote.id },
     // And select only existing JSON data
     select: { vote_data: true },
   });
+
+  // findUnique returns null for a missing/invalid voter id. Guard before
+  // destructuring so an unknown link returns the handler's existing
+  // "Invalid voter link" response (see the `if (user)` else branch below)
+  // instead of throwing "Cannot destructure property 'vote_data' of null"
+  // and 500ing.
+  if (!voterRow) {
+    return res.status(400).send("Invalid voter link");
+  }
+  const { vote_data } = voterRow;
 
   // Collect voter information
   const user = await prisma.voters.findUnique({


### PR DESCRIPTION
## Root cause

`pages/api/events/vote.js` destructured the voter lookup result directly:

```js
const { vote_data } = await prisma.voters.findUnique({ where: { id: vote.id }, ... });
```

`findUnique` returns **null** for a missing/invalid voter id. Destructuring `null` throws `TypeError: Cannot destructure property 'vote_data' of null` → an uncaught **500**, and it fires **before** the handler's existing `if (user)` check (~l.34) could return its intended response. This is a likely source of some "Internal server error" reports for bad/expired voter links.

## Fix

Capture the row, null-check it, then destructure:

```js
const voterRow = await prisma.voters.findUnique({ where: { id: vote.id }, select: { vote_data: true } });
if (!voterRow) {
  return res.status(400).send("Invalid voter link");
}
const { vote_data } = voterRow;
```

## Status code choice — `400 "Invalid voter link"`

I deliberately did **not** introduce a 404, even though a missing link is "naturally" not-found. **This exact handler already defines the not-found response for a nonexistent voter**: its `if (user)` else branch returns `res.status(400).send("Invalid voter link")` (l.93 on main). The bug is simply that the l.18 destructure crashes before that branch is reached.

Returning the **same `400 "Invalid voter link"`** makes the invalid-link path reach the handler's own intended outcome, byte-identical to its existing behavior — rather than inventing a second, conflicting response (a 404) for an identical condition. Consistency within the handler beats abstract REST purity here. (For reference, the file does use 404 elsewhere — `"Event not found"` in `handlePublicSubmission` — but that's a different entity; the voter-not-found convention in this handler is the 400.)

## Scope

- Only the l.18 lookup/destructure is changed. The separate **null-`vote_data`** guard added at ~l.60 in PR #36 is **untouched**.
- The now-redundant `if (user)` else branch is left as-is (harmless defensive code) to keep the diff minimal.

## Tests

- `node scripts/test-access.js` → **27 passed, 0 failed**
- `node scripts/test-privacy.js` → **31 passed, 0 failed**

Not deployed, not run against the droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)