### PR TITLE
Harden details.js edge cases (null event_data + participation divide-by-zero)

### DIFF
--- a/pages/api/events/details.js
+++ b/pages/api/events/details.js
@@ -38,8 +38,10 @@ export default async (req, res) => {
   if (isAdmin || (moment() > moment(event.end_event_date))) {
     // Pass voting statistics to endpoint
     statistics = generateStatistics(
-      // Number of voteable subjects
-      JSON.parse(event.event_data).length,
+      // Number of voteable subjects. event_data is Json? (nullable); guard
+      // the parse so a null event_data yields 0 subjects instead of throwing
+      // "Cannot read property 'length' of null".
+      event.event_data ? JSON.parse(event.event_data).length : 0,
       // Number of max voters
       event.num_voters,
       // Number of credits per voter
@@ -49,8 +51,9 @@ export default async (req, res) => {
     );
   }
 
-  // Parse event_data
-  event.event_data = JSON.parse(event.event_data);
+  // Parse event_data. Same null guard as above — a null event_data becomes
+  // an empty array rather than throwing.
+  event.event_data = event.event_data ? JSON.parse(event.event_data) : [];
 
   // If event is concluded or private_key enables administrator access
   if (isAdmin || (moment() > moment(event.end_event_date))) {
@@ -139,7 +142,11 @@ function generateStatistics(subjects, num_voters, credits_per_voter, voters) {
     numberVoters,
     numberVotesTotal: credits_per_voter * num_voters,
     numberVotes,
-    voterParticiptation: (voters.length / numberVoters) * 100,
+    // Guard divide-by-zero: when nobody has voted numberVoters is 0, which
+    // would yield Infinity/NaN. Report 0% participation instead. (Field name
+    // typo kept as-is to avoid breaking consumers that read this key.)
+    voterParticiptation:
+      numberVoters > 0 ? (voters.length / numberVoters) * 100 : 0,
     qvRaw,
     linear,
     qv,


### PR DESCRIPTION
Two small defensive guards in `pages/api/events/details.js`, both for conditions that shouldn't occur in normal operation. Minimal inline guards, no refactor, **no behavior change for valid data**.

## (a) Null `event_data` parse — real crash guard

`event_data` is `Json?` (nullable). It's parsed in two places, **both of which throw on null**:
- `JSON.parse(event.event_data).length` — passed as the subject count into `generateStatistics` (l.42).
- `event.event_data = JSON.parse(event.event_data)` — re-assignment before chart generation (l.53).

A null `event_data` throws `TypeError: Cannot read property 'length' of null` (or a parse error). Note both sites matter: for an admin/concluded view the first throws; for a non-admin ongoing view the first is skipped and the **second** throws — so guarding only one would leave the endpoint still crashing. Each parse is now null-guarded:
```js
event.event_data ? JSON.parse(event.event_data).length : 0   // 0 subjects
event.event_data ? JSON.parse(event.event_data) : []         // empty array
```

## (b) Participation divide-by-zero — cosmetic

In `generateStatistics`:
```js
voterParticiptation: (voters.length / numberVoters) * 100
```
When nobody has voted, `numberVoters` is `0` → `Infinity` (or `NaN` for `0/0`). This is **not a throw** — it just renders a nonsense participation figure. Now returns `0`:
```js
voterParticiptation: numberVoters > 0 ? (voters.length / numberVoters) * 100 : 0
```
The misspelled `voterParticiptation` key is **intentionally left as-is** to avoid breaking any consumer that reads that exact key.

## Stakes / scope

- (a) is a genuine crash guard; (b) is cosmetic (NaN display, not a crash). Both low-stakes hardening.
- For valid data, every code path is byte-for-byte equivalent — the guards only change the null/zero edge cases.
- Does **not** extract `generateStatistics` or add `lib/statistics.js` — that's a separate task.

## Tests
- `node scripts/test-access.js` → **27 passed, 0 failed**
- `node scripts/test-privacy.js` → **31 passed, 0 failed**

Not deployed, not run against the droplet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)