### PR TITLE
Drop stats denominators for public-link events

### DIFF
--- a/pages/event.js
+++ b/pages/event.js
@@ -12,6 +12,7 @@ import Datetime from "react-datetime"; // Datetime component
 import { useState, useEffect } from "react"; // State handling
 import axios from "axios"; // Axios for requests
 import { buildVotersSheet, shouldIncludeVotersSheet } from "lib/export";
+import { LINK_MODES } from "lib/access"; // Link-mode constants
 
 // Setup fetcher for SWR
 const fetcher = (url) => fetch(url).then((r) => r.json());
@@ -502,8 +503,15 @@ function Event({ query }) {
                 <div className="event__sub_section">
                   <label>Voting Participants</label>
                   <h3>
+                    {/* For public-link events num_voters is not a real
+                        roster, so the "/ N" denominator is a meaningless
+                        leftover (and reads as nonsense like "23 / 10" once
+                        submissions exceed it). Show just the count for
+                        public; keep "x / N" for unique-link rosters. */}
                     {!loading && data
-                      ? `${data.statistics.numberVoters.toLocaleString()} / ${data.statistics.numberVotersTotal.toLocaleString()}`
+                      ? data.event.link_mode === LINK_MODES.PUBLIC
+                        ? `${data.statistics.numberVoters.toLocaleString()}`
+                        : `${data.statistics.numberVoters.toLocaleString()} / ${data.statistics.numberVotersTotal.toLocaleString()}`
                       : "Loading..."}
                   </h3>
                 </div>
@@ -511,7 +519,9 @@ function Event({ query }) {
                   <label>Credits Used</label>
                   <h3>
                     {!loading && data
-                      ? `${data.statistics.numberVotes.toLocaleString()} / ${data.statistics.numberVotesTotal.toLocaleString()}`
+                      ? data.event.link_mode === LINK_MODES.PUBLIC
+                        ? `${data.statistics.numberVotes.toLocaleString()}`
+                        : `${data.statistics.numberVotes.toLocaleString()} / ${data.statistics.numberVotesTotal.toLocaleString()}`
                       : "Loading..."}
                   </h3>
                 </div>


### PR DESCRIPTION
## What

The Event Statistics panel renders two **\"x / N\"** figures:

- **Voting Participants** — `numberVoters / numberVotersTotal`
- **Credits Used** — `numberVotes / numberVotesTotal`

In both, the denominator (`numberVotersTotal` / `numberVotesTotal`) derives from `num_voters` (the latter as `credits_per_voter * num_voters`). For **public-link** events `num_voters` is **not a real roster** — public voting is uncapped: each submission creates its own `Voters` row at vote time (`pages/api/events/vote.js` → `handlePublicSubmission`), and nothing compares the voter count against `num_voters`. So these denominators are roster-model leftovers that become nonsense once submissions exceed `num_voters` (e.g. `\"23 / 10\"`, `\"1400 / 990\"`).

## Change

Purely in the rendering layer (`pages/event.js`):

- When `link_mode === LINK_MODES.PUBLIC`, render each stat as **just the count** (`numberVoters`, `numberVotes`) with no denominator.
- When `link_mode` is unique, render **exactly as today** (`x / N`).

Labels are unchanged. `generateStatistics`' returned shape in `pages/api/events/details.js` is **untouched** — both displays still read the same computed values; only whether the denominator is shown changes. The unique-link render path is **byte-identical** to before.

`link_mode` was already in scope as `data.event.link_mode` (the Voter Access section already branches on it); this PR reuses the existing `LINK_MODES.PUBLIC` constant from `lib/access`.

## Tests

Render-only change; existing suites unaffected:

- `node scripts/test-access.js` → **27 passed, 0 failed**
- `node scripts/test-privacy.js` → **31 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)